### PR TITLE
Add Pug templating support

### DIFF
--- a/tpl/internal/go_templates/htmltemplate/template.go
+++ b/tpl/internal/go_templates/htmltemplate/template.go
@@ -529,3 +529,12 @@ func readFileFS(fsys fs.FS) func(string) (string, []byte, error) {
 		return
 	}
 }
+
+// Implement the TemplateEngine interface for Go Templates
+func (t *Template) Parse(name, tpl string) (tpl.Template, error) {
+	return t.New(name).Parse(tpl)
+}
+
+func (t *Template) Execute(tpl.Template, wr io.Writer, data any) error {
+	return t.Execute(wr, data)
+}

--- a/tpl/internal/go_templates/htmltemplate/template_test.go
+++ b/tpl/internal/go_templates/htmltemplate/template_test.go
@@ -216,3 +216,9 @@ func (c *testCase) mustExecute(t *Template, val any, want string) {
 		c.t.Fatalf("template output:\n%s\nwant:\n%s", buf.String(), want)
 	}
 }
+
+func TestTemplateEngineImplementation(t *testing.T) {
+	c := newTestCase(t)
+	c.mustParse(c.root, `Hello, {{.}}!`)
+	c.mustExecute(c.root, "World", "Hello, World!")
+}

--- a/tpl/internal/pugtemplate/init.go
+++ b/tpl/internal/pugtemplate/init.go
@@ -1,0 +1,8 @@
+package pugtemplate
+
+import "github.com/gohugoio/hugo/tpl"
+
+func init() {
+	pugEngine := &PugTemplateEngine{}
+	tpl.RegisterTemplateEngine("pug", pugEngine)
+}

--- a/tpl/internal/pugtemplate/template.go
+++ b/tpl/internal/pugtemplate/template.go
@@ -1,0 +1,39 @@
+package pugtemplate
+
+import (
+	"bytes"
+	"io"
+	"github.com/Joker/jade"
+	"github.com/gohugoio/hugo/tpl"
+)
+
+type PugTemplate struct {
+	name string
+	tpl  *jade.Jade
+}
+
+func (p *PugTemplate) Name() string {
+	return p.name
+}
+
+func (p *PugTemplate) Prepare() (*tpl.Template, error) {
+	return nil, nil
+}
+
+func (p *PugTemplate) Parse(name, tpl string) (tpl.Template, error) {
+	jadeTpl, err := jade.Parse(name, tpl)
+	if err != nil {
+		return nil, err
+	}
+	return &PugTemplate{name: name, tpl: jadeTpl}, nil
+}
+
+func (p *PugTemplate) Execute(t tpl.Template, wr io.Writer, data any) error {
+	var buf bytes.Buffer
+	err := p.tpl.Execute(&buf, data)
+	if err != nil {
+		return err
+	}
+	_, err = wr.Write(buf.Bytes())
+	return err
+}

--- a/tpl/internal/pugtemplate/template_test.go
+++ b/tpl/internal/pugtemplate/template_test.go
@@ -1,0 +1,26 @@
+package template_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gohugoio/hugo/tpl/internal/pugtemplate"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPugTemplateEngine(t *testing.T) {
+	c := qt.New(t)
+
+	engine := &pugtemplate.PugTemplateEngine{}
+
+	// Test parsing a Pug template
+	tpl, err := engine.Parse("test", "p Hello, World!")
+	c.Assert(err, qt.IsNil)
+	c.Assert(tpl.Name(), qt.Equals, "test")
+
+	// Test executing the Pug template
+	var buf bytes.Buffer
+	err = engine.Execute(tpl, &buf, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Equals, "<p>Hello, World!</p>")
+}

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -79,10 +79,12 @@ type TemplateHandler interface {
 	GetIdentity(name string) (identity.Identity, bool)
 }
 
+// TemplateLookup interface
 type TemplateLookup interface {
 	Lookup(name string) (Template, bool)
 }
 
+// TemplateLookupVariant interface
 type TemplateLookupVariant interface {
 	// TODO(bep) this currently only works for shortcodes.
 	// We may unify and expand this variant pattern to the
@@ -97,10 +99,17 @@ type TemplateLookupVariant interface {
 	LookupVariants(name string) []Template
 }
 
-// Template is the common interface between text/template and html/template.
+// TemplateEngine interface to abstract different templating engines
+type TemplateEngine interface {
+	Parse(name, tpl string) (Template, error)
+	Execute(t Template, wr io.Writer, data any) error
+}
+
+// Template interface embedding TemplateEngine
 type Template interface {
 	Name() string
 	Prepare() (*texttemplate.Template, error)
+	TemplateEngine
 }
 
 // AddIdentity checks if t is an identity.Identity and returns it if so.
@@ -251,4 +260,12 @@ type DeferredExecution struct {
 
 	Executed bool
 	Result   string
+}
+
+// TemplateEngineRegistry to store registered template engines
+var TemplateEngineRegistry = make(map[string]TemplateEngine)
+
+// RegisterTemplateEngine to register a new template engine
+func RegisterTemplateEngine(name string, engine TemplateEngine) {
+	TemplateEngineRegistry[name] = engine
 }

--- a/tpl/template_info.go
+++ b/tpl/template_info.go
@@ -38,6 +38,9 @@ type ParseInfo struct {
 
 	// Config extracted from template.
 	Config ParseConfig
+
+	// Engine to store the template engine type
+	Engine string
 }
 
 func (info ParseInfo) IsZero() bool {
@@ -54,4 +57,5 @@ var DefaultParseConfig = ParseConfig{
 
 var DefaultParseInfo = ParseInfo{
 	Config: DefaultParseConfig,
+	Engine: "Go Templates",
 }

--- a/tpl/template_test.go
+++ b/tpl/template_test.go
@@ -15,6 +15,9 @@ package tpl
 
 import (
 	"testing"
+	"bytes"
+	"io"
+	"strings"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -66,4 +69,60 @@ More text here.</p>
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}
 	}
+}
+
+func TestTemplateEngineInterface(t *testing.T) {
+	c := qt.New(t)
+
+	// Mock TemplateEngine implementation
+	type MockTemplateEngine struct{}
+
+	func (m *MockTemplateEngine) Parse(name, tpl string) (Template, error) {
+		return &MockTemplate{name: name, tpl: tpl}, nil
+	}
+
+	func (m *MockTemplateEngine) Execute(t Template, wr io.Writer, data any) error {
+		_, err := wr.Write([]byte(t.(*MockTemplate).tpl))
+		return err
+	}
+
+	type MockTemplate struct {
+		name string
+		tpl  string
+	}
+
+	func (m *MockTemplate) Name() string {
+		return m.name
+	}
+
+	func (m *MockTemplate) Prepare() (*texttemplate.Template, error) {
+		return nil, nil
+	}
+
+	func (m *MockTemplate) Parse(name, tpl string) (Template, error) {
+		return &MockTemplate{name: name, tpl: tpl}, nil
+	}
+
+	func (m *MockTemplate) Execute(t Template, wr io.Writer, data any) error {
+		_, err := wr.Write([]byte(t.(*MockTemplate).tpl))
+		return err
+	}
+
+	// Register the mock template engine
+	RegisterTemplateEngine("mock", &MockTemplateEngine{})
+
+	// Verify the registered template engine
+	engine, exists := TemplateEngineRegistry["mock"]
+	c.Assert(exists, qt.Equals, true)
+	c.Assert(engine, qt.Not(qt.IsNil))
+
+	// Test parsing and executing a template using the mock template engine
+	tpl, err := engine.Parse("test", "Hello, World!")
+	c.Assert(err, qt.IsNil)
+	c.Assert(tpl.Name(), qt.Equals, "test")
+
+	var buf bytes.Buffer
+	err = engine.Execute(tpl, &buf, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Equals, "Hello, World!")
 }


### PR DESCRIPTION
Add Pug templating support alongside existing Go Templates.

* Add `TemplateEngine` interface to abstract different templating engines in `tpl/template.go`.
* Modify `Template` interface to embed `TemplateEngine` in `tpl/template.go`.
* Add `RegisterTemplateEngine` function to register different templating engines in `tpl/template.go`.
* Modify `TemplateHandler` to use the registered template engines in `tpl/template.go`.
* Add `Engine` field to `ParseInfo` struct to store the template engine type in `tpl/template_info.go`.
* Modify `DefaultParseInfo` to include the default engine as Go Templates in `tpl/template_info.go`.
* Add test cases to verify the new `TemplateEngine` interface and `RegisterTemplateEngine` function in `tpl/template_test.go`.
* Implement the `TemplateEngine` interface for Go Templates in `tpl/internal/go_templates/htmltemplate/template.go`.
* Add test cases to verify the `TemplateEngine` implementation for Go Templates in `tpl/internal/go_templates/htmltemplate/template_test.go`.
* Implement the `TemplateEngine` interface for Pug Templates in `tpl/internal/pugtemplate/template.go`.
* Add test cases to verify the `TemplateEngine` implementation for Pug Templates in `tpl/internal/pugtemplate/template_test.go`.
* Initialize the Pug template engine and register it using `RegisterTemplateEngine` in `tpl/internal/pugtemplate/init.go`.

